### PR TITLE
added regex boundaries to keyword definitions

### DIFF
--- a/syntaxes/kxi.tmLanguage.json
+++ b/syntaxes/kxi.tmLanguage.json
@@ -42,19 +42,19 @@
 	"repository": {
 		"keyword-control": {
 			"name": "keyword.control.kxi",
-			"match": "break|case|default|else|if|new|return|switch|while"
+			"match": "\\b(break|case|default|else|if|new|return|switch|while)\\b"
 		},
 		"keyword-other": {
 			"name": "keyword.other.kxi",
-			"match": "false|kxi\\d{4}|null|true"
+			"match": "\\b(false|kxi\\d{4}|null|true)\\b"
 		},
 		"accessibility-modifier": {
 			"name": "storage.modifier.kxi",
-			"match": "public|private"
+			"match": "\\b(public|private)\\b"
 		},
 		"types": {
 			"name": "keyword.other.kxi",
-			"match": "bool|char|string|void|int"
+			"match": "\\b(bool|char|string|void|int)\\b"
 		},
 		"function-name": {
 			"match": "(([A-Za-z]|_)\\w*)\\(",


### PR DESCRIPTION
previously the syntax highlighting was not functioning properly for identifiers that contained keywords. (i.e. ifAllowed, strings, character, etc.) Adding the word boundary character '\b' in the regex fixed this problem.  